### PR TITLE
fix for yum sometimes breaking on overlayfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM centos:centos7
 
 RUN yum update -y && yum clean all
-ONBUILD RUN yum update -y && yum clean all && && rpm --rebuilddb
+ONBUILD RUN yum update -y && yum clean all && rpm --rebuilddb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM centos:centos7
 
 RUN yum update -y && yum clean all
-ONBUILD RUN yum update -y && yum clean all
+ONBUILD RUN yum update -y && yum clean all && && rpm --rebuilddb


### PR DESCRIPTION
Downstream will sometimes (always?) break if you do:-

```
RUN yum -y install git
RUN yum -y install curl
```

Basically any two strings of yum has problems, whether it's an install or update, or whatever.  The RPM command should stop this from happening.
