### PR TITLE
Remove cached RPMs in downstream images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM centos:centos7
 
 RUN yum clean all && yum update -y && yum clean all && rpm --rebuilddb
-ONBUILD RUN yum clean all && yum update -y && yum clean all && rpm --rebuilddb
+ONBUILD RUN yum clean all && yum update -y && yum clean all && rm -rf /var/cache/yum && rpm --rebuilddb

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
 FROM centos:centos7
 
-RUN yum clean all && yum update -y && yum clean all && rpm --rebuilddb
-ONBUILD RUN yum clean all && yum update -y && yum clean all && rm -rf /var/cache/yum && rpm --rebuilddb
+RUN yum clean all \
+ && yum update -y \
+ && yum clean all \
+ && rpm --rebuilddb
+
+ONBUILD RUN yum clean all \
+         && yum update -y \
+         && yum clean all \
+         && rm -rf /var/cache/yum \
+         && rpm --rebuilddb


### PR DESCRIPTION
This should reduce the size of any downstream images.