### PR TITLE
Support for OverlayFS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM centos:centos7
 
 RUN yum clean all \
+ && yum install yum-plugin-ovl \
  && yum update -y \
  && yum clean all \
  && rpm --rebuilddb


### PR DESCRIPTION
Yum triggers a bug relating to OverlayFS. This extra package should
implement a workaround.[1]

[1]: https://docs.docker.com/engine/userguide/storagedriver/overlayfs-driver/#limitations-on-overlayfs-compatibility