### PR TITLE
Prevent prompt for user input in CI build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:centos7
 
 RUN yum clean all \
- && yum install yum-plugin-ovl \
+ && yum install yum-plugin-ovl -y \
  && yum update -y \
  && yum clean all \
  && rm -rf /var/cache/yum \


### PR DESCRIPTION
This step is currently failing with the following:

```
Is this ok [y/d/N]: Exiting on user command
```

Add a `-y` flag to skip the prompt for user input.