### PR TITLE
Push latest on tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -33,6 +33,8 @@ pipeline:
     commands:
       - docker login -u="ukhomeofficedigital+drone" -p=$${DOCKER_PASSWORD} quay.io
       - docker tag centos-base:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/centos-base:$${DRONE_TAG}
+      - docker tag centos-base:$${DRONE_COMMIT_SHA} quay.io/ukhomeofficedigital/centos-base:latest
       - docker push quay.io/ukhomeofficedigital/centos-base:$${DRONE_TAG}
+      - docker push quay.io/ukhomeofficedigital/centos-base:latest
     when:
       event: tag


### PR DESCRIPTION
We often rebuild this image by re-tagging rather than pushing a new commit. This means that latest can fall behind. By pushing latest on tag we should be able to avoid this.